### PR TITLE
Fix 修复了使用油猴脚本，在mooc1网址下，反复跳转到课程第一个视频的问题

### DIFF
--- a/v3_optimized.user.js
+++ b/v3_optimized.user.js
@@ -428,39 +428,46 @@
             },
         };
 
-        try {
+        function startWhenReady() {
+            if (location.hostname.startsWith('mooc1')) {
+                if ($('#coursetree').find('.posCatalog_select').length > 0) {
+                    window.app.run();
+                    return;
+                }
+                console.log('%c等待课程目录数据加载...', 'color:#FF9800');
+                setTimeout(startWhenReady, 500);
+                return;
+            }
             window.app.run();
-
-            const preventPause = (e) => {
-                e.stopPropagation();
-                e.preventDefault();
-            };
-
-            const resumePlaybackNow = () => {
-                if (window.app && typeof window.app._tryResumePlayback === 'function') {
-                    window.app._tryResumePlayback('page-event');
-                }
-            };
-
-            document.addEventListener('mouseleave', preventPause);
-            window.addEventListener('mouseleave', preventPause);
-            document.addEventListener('mouseout', preventPause);
-            window.addEventListener('mouseout', preventPause);
-
-            window.addEventListener('blur', () => {
-                console.log('%c页面失去焦点，保持播放状态', 'color:#607D8B');
-                resumePlaybackNow();
-            });
-
-            document.addEventListener('visibilitychange', () => {
-                if (document.hidden) {
-                    console.log('%c页面切到后台，尝试保持播放状态', 'color:#607D8B');
-                }
-                resumePlaybackNow();
-            });
-        } catch (error) {
-            console.error('%c脚本运行失败: ', 'color:#F44336;font-weight:bold', error.message);
-            console.log('请检查是否在正确的课程播放页面，或者页面结构是否再次发生改变。');
         }
+        startWhenReady();
+
+        const preventPause = (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+        };
+
+        const resumePlaybackNow = () => {
+            if (window.app && typeof window.app._tryResumePlayback === 'function') {
+                window.app._tryResumePlayback('page-event');
+            }
+        };
+
+        document.addEventListener('mouseleave', preventPause);
+        window.addEventListener('mouseleave', preventPause);
+        document.addEventListener('mouseout', preventPause);
+        window.addEventListener('mouseout', preventPause);
+
+        window.addEventListener('blur', () => {
+            console.log('%c页面失去焦点，保持播放状态', 'color:#607D8B');
+            resumePlaybackNow();
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                console.log('%c页面切到后台，尝试保持播放状态', 'color:#607D8B');
+            }
+            resumePlaybackNow();
+        });
     }
 })();


### PR DESCRIPTION
之前在edge/chrome使用油猴脚本加装[v3_optimized.user.js](https://github.com/chaolucky18/xuexitongScript/blob/master/v3_optimized.user.js)刷课时，一个视频播放完之后，不会自动播放下一个视频，而是播放该课程下的第一个视频，具体原因是脚本在获取当前播放的是哪个视频时，界面还没加载完
加了个页面加载进度判断，现在可以正确获取当前播放的是哪个视频